### PR TITLE
Update openInWindsurf return type and usage

### DIFF
--- a/src/open-with-windsurf.tsx
+++ b/src/open-with-windsurf.tsx
@@ -39,10 +39,12 @@ export default async function OpenWithWindsurf() {
 
     // Open the first selected item in Windsurf
     const targetPath = selectedItems[0].path;
-    await openInWindsurf(targetPath);
+    const opened = await openInWindsurf(targetPath);
 
-    // Show success HUD
-    await showHUD(`Opened ${path.basename(targetPath)} in Windsurf`);
+    // Show success HUD only when the item was opened successfully
+    if (opened) {
+      await showHUD(`Opened ${path.basename(targetPath)} in Windsurf`);
+    }
   } catch (_error) {
     console.error("Error in OpenWithWindsurf:", _error);
     await showToast({

--- a/src/utils/windsurf.ts
+++ b/src/utils/windsurf.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 
 const execAsync = promisify(exec);
 
-export async function openInWindsurf(filePath: string): Promise<void> {
+export async function openInWindsurf(filePath: string): Promise<boolean> {
   try {
     // Check if path exists
     if (!fs.existsSync(filePath)) {
@@ -17,7 +17,7 @@ export async function openInWindsurf(filePath: string): Promise<void> {
         title: "Path not found",
         message: `The path "${filePath}" does not exist`,
       });
-      return;
+      return false;
     }
 
     // Determine if it's a file or folder
@@ -39,11 +39,7 @@ export async function openInWindsurf(filePath: string): Promise<void> {
       await saveWindsurfProject(project);
     }
 
-    await showToast({
-      style: Toast.Style.Success,
-      title: "Opened in Windsurf",
-      message: `${isDirectory ? "Folder" : "File"}: ${path.basename(filePath)}`,
-    });
+    return true;
   } catch (error) {
     console.error("Error opening in Windsurf:", error);
     await showToast({
@@ -51,6 +47,7 @@ export async function openInWindsurf(filePath: string): Promise<void> {
       title: "Failed to open in Windsurf",
       message: error instanceof Error ? error.message : "Unknown error",
     });
+    return false;
   }
 }
 

--- a/src/windsurf-projects.tsx
+++ b/src/windsurf-projects.tsx
@@ -41,9 +41,11 @@ export default function WindsurfProjects() {
   }
 
   async function handleOpenProject(project: WindsurfProject) {
-    await openInWindsurf(project.path);
-    // Refresh the list to update the "last opened" time
-    await loadProjects();
+    const opened = await openInWindsurf(project.path);
+    // Refresh the list to update the "last opened" time only if opened successfully
+    if (opened) {
+      await loadProjects();
+    }
   }
 
   async function handleRemoveProject(project: WindsurfProject) {


### PR DESCRIPTION
## Summary
- make `openInWindsurf` return a boolean indicating success
- adapt commands to handle the new return type
- only show HUD when the file actually opened

## Testing
- `npm run lint` *(fails: `ray` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e7b74b5c8323ab16782ec29ec6cf